### PR TITLE
gcm cask: Add arm64 support

### DIFF
--- a/Casks/git-credential-manager-core.rb
+++ b/Casks/git-credential-manager-core.rb
@@ -1,13 +1,14 @@
 cask 'git-credential-manager-core' do
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
   name 'Git Credential Manager'
   homepage 'https://aka.ms/gcm'
 
   version "2.0.785"
   sha256 '064f8422122d84577b1dcd7845c942ad78aa899190fa5b5811a96528d1e89896'
 
-  url "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v#{version.major_minor_patch}/gcm-osx-x64-#{version.major_minor_patch}.pkg"
+  url "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v#{version.major_minor_patch}/gcm-osx-#{arch}-#{version.major_minor_patch}.pkg"
 
-  pkg "gcm-osx-x64-#{version}.pkg", allow_untrusted: true
+  pkg "gcm-osx-#{arch}-#{version}.pkg", allow_untrusted: true
 
   uninstall script: {
                       executable: '/usr/local/share/gcm-core/uninstall.sh',


### PR DESCRIPTION
Update git-credential-manager-core cask to determine whether to install
the x64 pkg or the arm64 pkg based on the user's CPU.